### PR TITLE
change manual access revoke

### DIFF
--- a/TaranzaSoul/Services/Logger.cs
+++ b/TaranzaSoul/Services/Logger.cs
@@ -378,14 +378,19 @@ namespace TaranzaSoul
 
                     if (loggedUser.ApprovedAccess)
                     {
-                        await dbhelper.RevokeApproval(before.Id);
+                        // don't revoke access
+                        // await dbhelper.RevokeApproval(before.Id);
 
                         string output = "";
 
-                        if (config.AlternateStaffMention)
-                            output = $"<@&{config.AlternateStaffId}> {before.Mention} has had their access revoked manually.";
-                        else
-                            output = $"<@&{config.StaffId}> {before.Mention} has had their access revoked manually.";
+                        // if (config.AlternateStaffMention)
+                        //     output = $"<@&{config.AlternateStaffId}> {before.Mention} has had their access revoked manually.";
+                        // else
+                        //     output = $"<@&{config.StaffId}> {before.Mention} has had their access revoked manually.";
+
+                        // send notification without a ping
+                        output = $"{before.Mention} has had their access revoked manually.";
+
 
                         await (client.GetGuild(config.HomeGuildId).GetChannel(config.MainChannelId) as ISocketMessageChannel)
                             .SendMessageAsync(output);


### PR DESCRIPTION
This PR addresses two issues:

1. Don't actually revoke access when the role is manually removed, as this is usually meant to be temporary (ex. roleban).
2. Don't ping all mods when it happens, as they've been complaining about it.